### PR TITLE
Version 1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 *.pyc
 *.pyo
+*.lib
+*.pdb
+*.so
+*.a
+*.launch
 build/
 __pycache__/
 onesdk_shared.dll
@@ -10,7 +15,13 @@ dist/
 /tmp/
 *.egg-info
 .pytest_cache/
+venv/
+.venv/
+.tox/
+.vscode
+*.whl
+db.sqlite3
+/.checkstyle
 /.project
 /.pydevproject
-/.README.md.html
-/.settings
+.settings/

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,6 @@
-pylint<2.5
+tox<4
+pylint<2.5; python_version >= '3.0'
+pylint<1.10; python_version < '3.0'
+sphinx<6
+pytest<5; python_version < '3.5'
+pytest<7.2; python_version >= '3.5'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,17 +39,6 @@ import datetime
 
 from oneagent.version import __version__ as version
 
-# Fix spurious "= None" for instance attributes
-# https://github.com/sphinx-doc/sphinx/issues/2044
-from sphinx.ext.autodoc import (
-    ClassLevelDocumenter, InstanceAttributeDocumenter)
-
-def iad_add_directive_header(self, sig):
-    ClassLevelDocumenter.add_directive_header(self, sig)
-
-InstanceAttributeDocumenter.add_directive_header = iad_add_directive_header
-
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -96,7 +85,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -121,7 +110,7 @@ html_theme = 'nature'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {'sidebarwidth': 500}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/tagging.rst
+++ b/docs/tagging.rst
@@ -120,3 +120,6 @@ Note these points:
 * You should take care that obtaining the incoming tag is not an expensive
   operation, as it can not be accounted for in the timings of the resulting
   path.
+* Both the string and byte tag are returned as a :class:`bytes` object
+  (:code:`str` bytestring in Python 2).
+  This is due to an oversight that cannot be fixed anymore without breaking compatibility.

--- a/samples/basic-sdk-sample/basic_sdk_sample.py
+++ b/samples/basic-sdk-sample/basic_sdk_sample.py
@@ -219,7 +219,12 @@ def mock_process_incoming_message():
             # the tracer ends.
             tracer.set_vendor_message_id('message_id')
             with tracer:
-                print('handle incoming message')
+
+                # Use tracecontext_get_current to log a trace/span ID identifiying the current node.
+                tinfo = sdk.tracecontext_get_current()
+                print('[!dt dt.trace_id={},dt.span_id={}] handle incoming message'.format(
+                    tinfo.trace_id, tinfo.span_id))
+
                 tracer.set_correlation_id('correlation_id')
 
 def mock_outgoing_message():

--- a/src/oneagent/__init__.py
+++ b/src/oneagent/__init__.py
@@ -242,7 +242,7 @@ def initialize(sdkopts=(), sdklibname=None, forkable=False):
         Python SDK version.
     :param bool forkable: Use the SDK in 'forkable' mode.
 
-    :rtype: .InitResult
+    :rtype: InitResult
     '''
 
     global _sdk_ref_count #pylint:disable=global-statement

--- a/src/oneagent/_impl/native/sdknulliface.py
+++ b/src/oneagent/_impl/native/sdknulliface.py
@@ -209,9 +209,9 @@ class SDKNullInterface(object): #pylint:disable=too-many-public-methods
         pass
 
     def tracer_get_outgoing_tag(self, tracer_h, use_byte_tag=False):
-        if use_byte_tag:
-            return six.binary_type()
-        return six.text_type()
+        # This was originally meant to return a string for use_byte_tag=False
+        # but the real implementation doesn't do it that way.
+        return six.binary_type()
 
     def tracer_set_incoming_string_tag(self, tracer_h, tag):
         pass
@@ -281,3 +281,6 @@ class SDKNullInterface(object): #pylint:disable=too-many-public-methods
 
     def customservicetracer_create(self, service_method, service_name):
         return NULL_HANDLE
+
+    def tracecontext_get_current(self):
+        return (ErrorCode.NO_DATA, '00000000000000000000000000000000', '0000000000000000')

--- a/src/oneagent/sdk/__init__.py
+++ b/src/oneagent/sdk/__init__.py
@@ -640,3 +640,23 @@ class SDK(object): # pylint:disable=too-many-public-methods
         '''
         return tracers.CustomServiceTracer(
             self._nsdk, self._nsdk.customservicetracer_create(service_method, service_name))
+
+    def tracecontext_get_current(self):
+        ''' Retrieves the current W3C trace context's span and trace ID.
+
+            This function always returns a :class:`.TraceContextInfo` object (never None).
+            Check :attr:`.TraceContextInfo.is_valid` if you need to determine whether a valid
+            trace/span ID is available, but this should not usually be necessary because
+            an all-zero span/trace ID of the right length is still returned.
+
+            If you need to find out why the trace/span ID is zero, use the usual mechanism,
+            i.e. :meth:`.set_verbose_callback` and :meth:`.set_diagnostic_callback`.
+            The most common cause is that there is no tracer currently active.
+        '''
+
+        result_code, trace_id, span_id = self._nsdk.tracecontext_get_current()
+
+        # Note: We discard error information here, the interesting cases should be covered by
+        # the diagnostic/verbose callback. In difficult cases, calling through to
+        # the raw _nsdk method might be a way to get more error information.
+        return TraceContextInfo(result_code == ErrorCode.SUCCESS, trace_id, span_id)

--- a/src/oneagent/sdk/tracers.py
+++ b/src/oneagent/sdk/tracers.py
@@ -35,16 +35,23 @@ class OutgoingTaggable(object):
 
     @property
     def outgoing_dynatrace_string_tag(self):
-        '''Get a string tag (:class:`str` on Python 3, :class:`unicode` on
-        Python 2) identifying the node of this tracer. Must be called between
-        starting and ending the tracer (i.e., while it is started).'''
+        '''Get a ASCII string tag (as :class:`bytes` on Python 3, :code:`str`
+        on Python 2) identifying the node of this tracer. Must be called between
+        starting and ending the tracer (i.e., while it is started).
+
+        .. warning:: This method was originally meant to return a :class:`unicode` object on
+            Python 2 and a :class:`str` on Python 3 and was documented as such until version 1.4.
+            However, it has always been returning bytes only. Use :code:`.decode('utf-8')`
+            (:meth:`bytes.decode`) if you need an actual string.
+        '''
         return self.nsdk.tracer_get_outgoing_tag(self.handle, False)
 
     @property
     def outgoing_dynatrace_byte_tag(self):
         '''Get a :class:`bytes` tag identifying the node of this tracer. Must be
         called between starting and ending the tracer (i.e., while it is
-        started).'''
+        started).
+        '''
         return self.nsdk.tracer_get_outgoing_tag(self.handle, True)
 
 class Tracer(object):

--- a/src/oneagent/version.py
+++ b/src/oneagent/version.py
@@ -21,12 +21,12 @@ from oneagent._impl.native.sdkversion import OnesdkStubVersion
 # That's the OneAgent SDK for Python version.
 # See https://www.python.org/dev/peps/pep-0440/ "Version Identification and
 # Dependency Specification"
-__version__ = '1.4.0'
+__version__ = '1.5.0'
 
 # Define the OneAgent SDK for C/C++ version which should be shipped with this
 # Python SDK version.
-shipped_c_stub_version = '1.6.1'
+shipped_c_stub_version = '1.7.1'
 
 # Below are the minimum and maximum required/supported OneAgent SDK for C/C++ versions.
-min_stub_version = OnesdkStubVersion(1, 6, 1)
+min_stub_version = OnesdkStubVersion(1, 7, 1)
 max_stub_version = OnesdkStubVersion(2, 0, 0)

--- a/test-util-src/sdkmockiface.py
+++ b/test-util-src/sdkmockiface.py
@@ -294,7 +294,7 @@ def _entry_field(func):
 def _strcheck(val, optional=False):
     if optional and val is None:
         return
-    if not isinstance(val, six.string_types):
+    if not isinstance(val, (six.text_type, six.binary_type)):
         raise TypeError('Expected a string type but got {}({})'.format(
             type(val), val))
     if not optional and not val.strip():
@@ -640,7 +640,7 @@ class SDKMockInterface(object): #pylint:disable=too-many-public-methods
         _livecheck(tracer_h, TracerHandle, TracerHandle.STARTED)
         if use_byte_tag:
             return tracer_h.out_tag
-        return base64.b64encode(tracer_h.out_tag).decode('ASCII')
+        return base64.b64encode(tracer_h.out_tag)
 
     @_entry_field
     def tracer_set_incoming_string_tag(self, tracer_h, tag):
@@ -742,3 +742,6 @@ class SDKMockInterface(object): #pylint:disable=too-many-public-methods
         handle.service_method = service_method
         handle.service_name = service_name
         return handle
+
+    def tracecontext_get_current(self):
+        return (ErrorCode.AGENT_NOT_ACTIVE, '00000000000000000000000000000000', '0000000000000000')

--- a/test/test_load_old_agent.py
+++ b/test/test_load_old_agent.py
@@ -23,6 +23,7 @@ from oneagent import InitResult
 from oneagent.common import AgentState
 
 @pytest.mark.dependsnative
+@pytest.mark.skipif('DT_OLDAGENTLIBRARY' not in os.environ, reason="See OA-8673, EP-918")
 def test_load_old_agent():
     saved_path = os.environ.get('DT_AGENTLIBRARY', '')
     try:

--- a/test/test_load_old_agent.py
+++ b/test/test_load_old_agent.py
@@ -23,7 +23,9 @@ from oneagent import InitResult
 from oneagent.common import AgentState
 
 @pytest.mark.dependsnative
-@pytest.mark.skipif('DT_OLDAGENTLIBRARY' not in os.environ, reason="See OA-8673, EP-918")
+@pytest.mark.skipif(
+    'DT_OLDAGENTLIBRARY' not in os.environ,
+    reason="No easy way to download these very old agent versions")
 def test_load_old_agent():
     saved_path = os.environ.get('DT_AGENTLIBRARY', '')
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ skip_missing_interpreters=true
 setenv =
     test: PYTHONDONTWRITEBYTECODE = 1
     PYTHONPATH = {toxinidir}/test-util-src{:}{toxinidir}/samples/basic-sdk-sample
+    py34: VIRTUALENV_PIP=19.1.*
+    py34: VIRTUALENV_SETUPTOOLS = 43.*
+    py35: VIRTUALENV_SETUPTOOLS = 44.*
+    py34: VIRTUALENV_WHEEL = 0.33.*
+    py35,py36: VIRTUALENV_WHEEL = 0.37.*
 passenv = DT_AGENTLIBRARY DT_OLDAGENTLIBRARY
 changedir =
     test: test
@@ -18,14 +23,14 @@ commands =
     lint-py27,lint-pypy: pylint test --disable=redefined-outer-name,unidiomatic-typecheck --ignore-patterns=.*py3.*
 deps =
     -c constraints.txt
-    py27-lint: pylint~=1.9
-    lint-!py27-!pypy: pylint~=2.4
-    pytest
-    mock
+    lint-!pypy: pylint<9999
+    pytest<9999
+    mock<9999
 
 [testenv:docs]
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {distdir}/oneagent-docs-html
 changedir = docs
 deps =
+    -c constraints.txt
     sphinx


### PR DESCRIPTION
Proposed release notes:


### Version 1.5.0

Changes:

* Adds limited [W3C trace context](#w3c-trace-context) support (for log enrichment).
* This version **no longer supports Python 2 (Python 2.7.x)**.
* This version **no longer supports Python 3.4.x**.

Announcements:

* ⚠️ **Deprecation announcement for older SDK versions:** Version 1.3 and all older versions have been put on the path to deprecation and will no longer be supported starting July 1, 2023. We strongly advise customers to upgrade to newest versions to avoid incompatibility and security risks. Customers need to upgrade to at least 1.4 but are encouraged to upgrade to the newest available version (1.5) if using Python >3.4 as there are no known incompatibilities or breaking changes other than the increased minimum Python version.
* ⚠️ **Deprecation announcement for using any SDK version with older Python versions:** Python 2.7.x has been put on the path to deprecation and no version of the SDK will be supported on this Python version starting July 1, 2023. Furthermore, we intend to release a similar deprecation announcement regarding versions 3.4-3.6 (which are no longer maintained by the Python project) soon (we plan that this will not become effective before 2023-07-01).